### PR TITLE
lock database for Uri being updated by different plugins

### DIFF
--- a/src/core/celery_config.py
+++ b/src/core/celery_config.py
@@ -15,6 +15,7 @@ def init_celery(app, celery_app):
     celery_app.conf.task_routes = {
         'approve-user': {'queue': 'altmetrics.approve-user'},
         'send-approval-request': {'queue': 'altmetrics.send-approval-request'},
+        'pull-metrics': {'queue': 'altmetrics.pull-metrics'},
         'process-plugin': {'queue': 'altmetrics.process-plugin'},
         'send-metrics-to-metrics-api': {
             'queue': 'altmetrics.send-metrics-to-metrics-api'

--- a/src/processor/tasks.py
+++ b/src/processor/tasks.py
@@ -4,6 +4,7 @@ from itertools import chain
 from arrow import utcnow
 from celery.utils.log import get_task_logger
 from flask import current_app
+from sqlalchemy.exc import OperationalError
 
 from core import celery_app, db
 from core.logic import get_enum_by_value
@@ -30,10 +31,14 @@ def process_plugin(
 ):
     # Get around objects not being JSON serializable for tasks.
     plugin = current_app.config.get('PLUGINS').get(plugin_name)
-    uri = Uri.query.get(uri_id)
     scrape = Scrape.query.get(scrape_id)
     origin = get_enum_by_value(Origins, origin_value)
     last_check = last_check_iso and datetime.fromisoformat(last_check_iso)
+
+    try:  # Lock DB row for this URI
+        uri = Uri.query.with_for_update(nowait=True).get(uri_id)
+    except OperationalError as exception:
+        raise self.retry(exc=exception, countdown=5, max_retries=10)
 
     event_dict = plugin.PROVIDER.process(
         uri,

--- a/src/processor/tasks.py
+++ b/src/processor/tasks.py
@@ -38,7 +38,7 @@ def process_plugin(
     try:  # Lock DB row for this URI
         uri = Uri.query.with_for_update(nowait=True).get(uri_id)
     except OperationalError as exception:
-        raise self.retry(exc=exception, countdown=5, max_retries=10)
+        raise self.retry(exc=exception, countdown=5, max_retries=120)
 
     event_dict = plugin.PROVIDER.process(
         uri,


### PR DESCRIPTION
Prevent different plugins trying to create the same entry, causing DB conflicts, by locking the row in the DB for that entry until the plugin has finished processing it. 

Trello card: https://trello.com/c/TvICorNn/2989-3-hirmeos-wp6