### PR TITLE
Schedule send metrics to metrics api

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -24,7 +24,7 @@ stderr_logfile_maxbytes = 0
 priority=200
 
 [program:run_pull_metrics]
-command=celery -A core.celery.celery worker -l info -Q altmetrics.process-plugin,altmetrics.pull-metrics,altmetrics.approve-user,altmetrics.send-approval-request,altmetrics.plugin-admin,altmetrics.send-metrics-to-metrics-api --hostname=metrics@%%h
+command=celery -A core.celery.celery worker -l info -Q altmetrics.process-plugin,altmetrics.pull-metrics,altmetrics.approve-user,altmetrics.send-approval-request,altmetrics.plugin-admin,altmetrics.send-metrics --hostname=metrics@%%h
 stderr_logfile=/dev/stderr
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes = 0

--- a/src/core/celery_config.py
+++ b/src/core/celery_config.py
@@ -17,9 +17,7 @@ def init_celery(app, celery_app):
         'send-approval-request': {'queue': 'altmetrics.send-approval-request'},
         'pull-metrics': {'queue': 'altmetrics.pull-metrics'},
         'process-plugin': {'queue': 'altmetrics.process-plugin'},
-        'send-metrics-to-metrics-api': {
-            'queue': 'altmetrics.send-metrics-to-metrics-api'
-        },
+        'send-metrics': {'queue': 'altmetrics.send-metrics'},
     }
 
 
@@ -55,6 +53,10 @@ def configure_celery(celery_app):
             'task': 'pull-metrics',
             'schedule': crontab(minute=0, hour=12, day_of_week='*')
         },
+        'send-metrics-every-day': {
+            'task': 'send-metrics',
+            'schedule': crontab(minute=0, hour=18, day_of_week='*')
+        },
         'check-wikipedia-references-every-day': {
             'task': 'check-wikipedia-references',
             'schedule': crontab(minute=0, hour=10, day_of_week='*')
@@ -74,7 +76,5 @@ def configure_celery(celery_app):
         'check-deleted-wikipedia-references': {
             'queue': 'altmetrics.plugin-admin'
         },
-        'send-metrics-to-metrics-api': {
-            'queue': 'altmetrics.send-metrics-to-metrics-api'
-        },
+        'send-metrics': {'queue': 'altmetrics.send-metrics'},
     }

--- a/src/processor/tasks.py
+++ b/src/processor/tasks.py
@@ -13,7 +13,6 @@ from processor.collections.reasons import doi_not_on_wikipedia_page
 from processor.logic import check_wikipedia_event
 from processor.models import Event, RawEvent, Scrape, Uri
 
-
 from .logic import send_events_to_metrics_api
 
 

--- a/src/processor/tasks.py
+++ b/src/processor/tasks.py
@@ -12,9 +12,9 @@ from core.settings import Origins, StaticProviders
 from processor.collections.reasons import doi_not_on_wikipedia_page
 from processor.logic import check_wikipedia_event
 from processor.models import Event, RawEvent, Scrape, Uri
-from services import ServiceHandler, MetricsAPIServiceDispatcher
 
-from .logic import prepare_metrics_data
+
+from .logic import send_events_to_metrics_api
 
 
 logger = get_task_logger(__name__)
@@ -148,15 +148,12 @@ def check_deleted_wikipedia_references():
     db.session.commit()
 
 
-@celery_app.task(name='send-metrics-to-metrics-api')
-def send_metrics_to_metrics_api(send_limit=None):
-    """ Send metrics to the metrics API using nameko."""
+@celery_app.task(name='send-metrics')
+def send_metrics():
+    """Send all metrics collected over the past day to the metrics-api. """
 
-    metrics_service = ServiceHandler(service=MetricsAPIServiceDispatcher)
-    for event in Event.query.all()[:send_limit]:  # temp send limit
-        data = prepare_metrics_data(
-            uri=event.uri.raw,
-            origin=event.origin,
-            created_at=event.created_at
-        )
-        metrics_service.send(data)
+    events_to_send = Event.query.filter(
+        Event.last_updated >= utcnow().shift(days=-1).datetime
+    )
+    logger.info(f'Sending {events_to_send.count()} new events to metrics-api')
+    send_events_to_metrics_api(events_to_send)


### PR DESCRIPTION
Schedule metrics to be sent to the `metrics-api` on a daily basis. 

Trello card: https://trello.com/c/TvICorNn/2989-3-hirmeos-wp6