### PR TITLE
Update tokens

### DIFF
--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1,3 +1,4 @@
+import json
 from logging import getLogger
 from urllib.parse import urlencode
 
@@ -39,8 +40,21 @@ class TokensViewSet(MethodView):
 
         return issue_token(user=user, lifespan=1800)
 
+    @http_auth_required
+    @account_approved
     def post(self):
-        return self.get()
+        user = current_user
+        if not user:
+            abort(401, "Invalid user credentials")
+
+        token = issue_token(user=user, lifespan=1800)
+
+        return {
+            'status': 'ok',
+            'count': 1,
+            'code': 200,
+            'data': [user.prepare_full_token_details(token)]
+        }
 
 
 bp.add_url_rule(

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -37,7 +37,10 @@ class TokensViewSet(MethodView):
         if not user:
             abort(401, "Invalid user credentials")
 
-        return issue_token(email=user.email)
+        return issue_token(user=user, lifespan=1800)
+
+    def post(self):
+        return self.get()
 
 
 bp.add_url_rule(

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -1,4 +1,3 @@
-import json
 from logging import getLogger
 from urllib.parse import urlencode
 

--- a/src/core/templates/demo/embedded-widget.html
+++ b/src/core/templates/demo/embedded-widget.html
@@ -188,7 +188,6 @@
     <script>
       let widget_params = {
         //"baseUrl": "http://0.0.0.0:8080/metrics/",  // Change token to use the live site
-        "token": "{{ token }}",
         "uri": "info:doi:10.5334/bbc",
         "widgetTitle": "Book Metrics",
       };

--- a/src/core/templates/demo/widget.html
+++ b/src/core/templates/demo/widget.html
@@ -49,7 +49,6 @@
     <script>
       let widget_params = {
         //"baseUrl": "http://0.0.0.0:8080/metrics/",  // Change token to use the live site
-        "token": "{{ token }}",
         "uri": "info:doi:10.5334/bbc",
         "widgetTitle": "Book Metrics",
       };

--- a/src/core/views.py
+++ b/src/core/views.py
@@ -14,8 +14,7 @@ class DemoWidgetViewSet(MethodView):
 
     @staticmethod
     def get():
-        widget_version = 'prototype-0.0.3'
-        token = issue_token('demo.user@email.co.uk', lifespan=60)
+        widget_version = '0.1.0'
 
         return render_template('demo/widget.html', **locals())
 
@@ -25,8 +24,7 @@ class DemoEmbeddedWidgetViewSet(MethodView):
 
     @staticmethod
     def get():
-        widget_version = 'prototype-0.0.3'
-        token = issue_token('demo.user@email.co.uk', lifespan=60)
+        widget_version = '0.1.0'
 
         return render_template('demo/embedded-widget.html', **locals())
 

--- a/src/user/models.py
+++ b/src/user/models.py
@@ -90,3 +90,12 @@ class User(Model, UserMixin):
 
     def __repr__(self):
         return f'<User {self.id}: {self.username}>'
+
+    def prepare_full_token_details(self, token):
+        return {
+            'surname': self.last_name,
+            'name': self.first_name,
+            'authority': 'admin' if self.has_role('admin') else 'user',
+            'token': token,
+            'email': self.email,
+        }

--- a/src/user/tokens.py
+++ b/src/user/tokens.py
@@ -27,8 +27,7 @@ def issue_token(user, lifespan=None):
         str: jwt token containing encrypted user data
     """
 
-    is_admin = user.has_role('admin') # 1 or 0
-    authority = ['user', 'admin'][is_admin]
+    authority = 'admin' if user.has_role('admin') else 'user'
 
     jwt_key = current_app.config.get('JWT_KEY')
     payload = {

--- a/src/user/tokens.py
+++ b/src/user/tokens.py
@@ -16,19 +16,27 @@ from flask import current_app, g
 from .models import User
 
 
-def issue_token(email, lifespan=None):
+def issue_token(user, lifespan=None):
     """ Create encoded JWT
 
     Args:
-        email (str): email used to identify user account
+        user (User): User account requesting token
         lifespan (int): (optional) Seconds token should be valid for
 
     Returns:
         str: jwt token containing encrypted user data
     """
 
+    is_admin = user.has_role('admin') # 1 or 0
+    authority = ['user', 'admin'][is_admin]
+
     jwt_key = current_app.config.get('JWT_KEY')
-    payload = {'email': email}
+    payload = {
+        'sub': f'acc:{user.email}',
+        'email': user.email,
+        'name': user.full_name,
+        'authority': authority,
+    }
 
     if lifespan:
         issued_at = datetime.utcnow()


### PR DESCRIPTION
Update the `get_tokens` response to support POST requests in a format matching the `tokens_api`.  This change is required to support sending new metrics to the Metrics API.

Trello card: https://trello.com/c/h14thFsd/3106-1-altmetrics-token-support-for-metrics-api