### PR TITLE
stagger queries when pulling metrics

### DIFF
--- a/docker/supervisord-workers.conf
+++ b/docker/supervisord-workers.conf
@@ -4,7 +4,7 @@ user=root
 
 [program:run_pull_metrics]
 command=celery -A core.celery.celery worker -l info
-  -Q altmetrics.process-plugin,altmetrics.pull-metrics,altmetrics.approve-user,altmetrics.send-approval-request,altmetrics.plugin-admin,altmetrics.send-metrics
+  -Q altmetrics.process-plugin,altmetrics.pull-metrics,altmetrics.trigger-plugins,altmetrics.approve-user,altmetrics.send-approval-request,altmetrics.plugin-admin,altmetrics.send-metrics
   --hostname=metrics@%%h
 stderr_logfile=/dev/stderr
 stdout_logfile=/dev/stdout

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -42,7 +42,7 @@ def create_app():
 
     from api.views import bp as api_blueprint
     from core.views import bp as core_blueprint
-    from processor.tasks import pull_metrics  # noqa
+    from processor.tasks import pull_metrics, trigger_plugins  # noqa
     from processor.views import bp as processor_blueprint
 
     app.register_blueprint(api_blueprint)

--- a/src/core/celery_config.py
+++ b/src/core/celery_config.py
@@ -13,6 +13,7 @@ def init_celery(app, celery_app):
     celery_app.conf.update(app.config)
 
     celery_app.conf.task_routes = {
+        'trigger-plugins': {'queue': 'altmetrics.trigger-plugins'},
         'approve-user': {'queue': 'altmetrics.approve-user'},
         'send-approval-request': {'queue': 'altmetrics.send-approval-request'},
         'pull-metrics': {'queue': 'altmetrics.pull-metrics'},
@@ -68,6 +69,7 @@ def configure_celery(celery_app):
     }
 
     celery_app.conf.task_routes = {
+        'trigger-plugins': {'queue': 'altmetrics.trigger-plugins'},
         'approve-user': {'queue': 'altmetrics.approve-user'},
         'send-approval-request': {'queue': 'altmetrics.send-approval-request'},
         'pull-metrics': {'queue': 'altmetrics.pull-metrics'},

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -128,7 +128,8 @@ class Config:
 
         # ## BEHAVIOUR #
 
-        DAYS_BEFORE_REFRESH = 1
+        DAYS_BEFORE_REFRESH = int(environ.get('DAYS_BEFORE_REFRESH', 1))
+        PULL_SET_SIZE = int(environ.get('PULL_SET_SIZE', 500))
 
         # ## Temporary solution to cref cited-by credentials
 

--- a/src/processor/logic.py
+++ b/src/processor/logic.py
@@ -266,3 +266,21 @@ def send_events_to_metrics_api(events, user, metrics_api_url):
             subject_id=event.subject_id,
         )
         requests.post(metrics_api_url, json=data, headers=header)
+
+
+def generate_queryset_chunks(full_queryset, set_size):
+    """Generator function to loop through a large queryset in smaller chunks.
+
+    Args:
+        full_queryset (BaseQuery): Database query.
+        set_size (int): number of entries per query subset.
+
+    Yields:
+        BaseQuery: Smaller subset of the original queryset.
+    """
+    step_size = 0
+    query_subset = full_queryset.limit(set_size).offset(step_size)
+    while query_subset.count():
+        yield query_subset
+        query_subset = full_queryset.limit(set_size).offset(step_size)
+        step_size += set_size


### PR DESCRIPTION
Trigger pulling of metrics as subsets of all URIs to be queried (smaller calls), which can be set in an environmental variable.

Trello card: https://trello.com/c/bgCqcwq3/3183-1-altmetrics-stagger-task-triggers